### PR TITLE
Refactored, fixed, and documented cost calculations, added more MK changes

### DIFF
--- a/src/components/TowerInsert/TowerInsert.tsx
+++ b/src/components/TowerInsert/TowerInsert.tsx
@@ -166,7 +166,8 @@ const TowerInsert: FC<TowerInsertProps> = ({
                   ...buffs,
                   firstFarm: e.target.checked,
                   firstMilitary: e.target.checked,
-                })} />} label="First Farm or First Military Tower" />
+                  firstSpike: e.target.checked,
+                })} />} label="First of its type of: Farm, Military Tower, or Spike" />
                 {farmingModifiers &&
                   <>
                     <FormControlLabel control={<Checkbox onChange={(e) => setBuffs({...buffs, overclock: e.target.checked})}/>} label="Overclock" />

--- a/src/models/Buff.ts
+++ b/src/models/Buff.ts
@@ -6,6 +6,7 @@ export type Buff = {
     ultraboosts: number;
     firstFarm: boolean;
     firstMilitary: boolean;
+    firstSpike: boolean;
     city: boolean;
     fertilizer: boolean;
     central: boolean;
@@ -26,6 +27,7 @@ export function createBuff(
     central = false,
     centralMarkets = 0,
     firstMilitary = false,
+    firstSpike = false,
     tradeEmpireMerchantmen = 0,
     tradeEmpireFavored = 0,
     energizer = false,
@@ -41,6 +43,7 @@ export function createBuff(
         central,
         centralMarkets,
         firstMilitary,
+        firstSpike,
         tradeEmpireMerchantmen,
         tradeEmpireFavored,
         energizer,
@@ -82,6 +85,12 @@ export function fixBuffs(type: TowerType, buff: Buff): Buff {
             ...createBuff(),
             discountVillage: buff.discountVillage,
             firstMilitary: buff.firstMilitary,
+        };
+    } else if (type === TowerType.Spike) {
+        return {
+            ...createBuff(),
+            discountVillage: buff.discountVillage,
+            firstSpike: buff.firstSpike,
         };
     } else if ([TowerType.Sniper, TowerType.Heli].includes(type)) {
         return {

--- a/src/models/Tower.ts
+++ b/src/models/Tower.ts
@@ -63,22 +63,19 @@ export class Tower {
         this.incomePerMinute = this.abilityIncome / (this.abilityCooldown / 60);
         this.abilityEfficiency = this.cost / this.abilityIncome;
 
-        const favoredSellPercentage = Math.min(
-            0.8 +
-            (mk === MK.On ? 0.05 : 0) +
-            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) +
-            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0),
-            0.95
-        );
 
-        const sellPercentage = (this.type === TowerType.Buccaneer && this.upgrades[2] >= 4) ? favoredSellPercentage :
-            0.7 +
-            (mk === MK.On ? 0.05 : 0) +
-            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) +
-            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0)
+
+        const sellPercentage = 0.7 + // default sale rate is 70%
+            (mk === MK.On ? 0.05 : 0) + // Better Sell Deals
+            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) + // Flat Pack Buildings
+            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0); //Banana Salvage
+
+        const favoredSellPercentage = Math.min( sellPercentage + 0.1, 0.95);
 
         this.favoredSellValue = Math.ceil(this.cost * favoredSellPercentage);
         this.sellValue = Math.ceil(this.cost * sellPercentage);
+        if (this.type === TowerType.Buccaneer && this.upgrades[2] >= 4)
+            this.sellValue = this.favoredSellValue;
         this.sellEfficiency = (this.cost - this.sellValue) / this.income;
         this.favoredSellEfficiency = (this.cost - this.favoredSellValue) / this.income;
         this.abilitySellEfficiency = (this.cost - this.sellValue) / this.abilityIncome;


### PR DESCRIPTION
## Refactored the cost calculator
While documenting any modifiers best I could, also to fix the cost discrepancies.   It took awhile to make sure the ninja logic actually matched, from some of the wiki descriptions (some of which makes no sense for ordering, as it generally isn't related).

They also don't use 1/3 or 0.3 but 0.33 for their third costs.

I got quite close but things were still off by a few dollars, took far too long to figure out they were using bankers rounding, and to learn the fact that hey .NET uses bankers rounding by default (so of course that makes sense).  Python 3 does the same (2 does not) but JS uses traditional rounding.
I now have a lovely excel version of the cost calculator to figure out when I changed something how many things matched official values vs not.

![image](https://github.com/blackeyefly/blackeyefly.github.io/assets/149419813/a8b539f0-3ad4-4638-9d36-4191bca1d271)

I haven't seen anything off by even a dollar now.

## Added all the missing MK cost changes
I believe, except for:
https://bloons.fandom.com/wiki/Come_On_Everybody!

I didn't want to add the detection like you had for some of the others.


## Minor other items
Your MK.On usage varied sometimes you checked mk vs MK.On sometimes you just used mk as true,  I made it consistent.  At least a place or two you also only used `&& MK.On` which would seem to give the wrong value if it was over off.

Probably all rounding it does should use bankers rounding as that is the .net default but I didn't want to mess with any of the other functions so there are new functions only cost uses.

This closes #1 