### PR TITLE
Improved Action figure cost calculation

### DIFF
--- a/src/components/TowerInsert/TowerInsert.tsx
+++ b/src/components/TowerInsert/TowerInsert.tsx
@@ -166,7 +166,8 @@ const TowerInsert: FC<TowerInsertProps> = ({
                   ...buffs,
                   firstFarm: e.target.checked,
                   firstMilitary: e.target.checked,
-                })} />} label="First Farm or First Military Tower" />
+                  firstSpike: e.target.checked,
+                })} />} label="First of its type of: Farm, Military Tower, or Spike" />
                 {farmingModifiers &&
                   <>
                     <FormControlLabel control={<Checkbox onChange={(e) => setBuffs({...buffs, overclock: e.target.checked})}/>} label="Overclock" />

--- a/src/models/Buff.ts
+++ b/src/models/Buff.ts
@@ -6,6 +6,7 @@ export type Buff = {
     ultraboosts: number;
     firstFarm: boolean;
     firstMilitary: boolean;
+    firstSpike: boolean;
     city: boolean;
     fertilizer: boolean;
     central: boolean;
@@ -26,6 +27,7 @@ export function createBuff(
     central = false,
     centralMarkets = 0,
     firstMilitary = false,
+    firstSpike = false,
     tradeEmpireMerchantmen = 0,
     tradeEmpireFavored = 0,
     energizer = false,
@@ -41,6 +43,7 @@ export function createBuff(
         central,
         centralMarkets,
         firstMilitary,
+        firstSpike,
         tradeEmpireMerchantmen,
         tradeEmpireFavored,
         energizer,
@@ -82,6 +85,12 @@ export function fixBuffs(type: TowerType, buff: Buff): Buff {
             ...createBuff(),
             discountVillage: buff.discountVillage,
             firstMilitary: buff.firstMilitary,
+        };
+    } else if (type === TowerType.Spike) {
+        return {
+            ...createBuff(),
+            discountVillage: buff.discountVillage,
+            firstSpike: buff.firstSpike,
         };
     } else if ([TowerType.Sniper, TowerType.Heli].includes(type)) {
         return {

--- a/src/models/Tower.ts
+++ b/src/models/Tower.ts
@@ -63,22 +63,19 @@ export class Tower {
         this.incomePerMinute = this.abilityIncome / (this.abilityCooldown / 60);
         this.abilityEfficiency = this.cost / this.abilityIncome;
 
-        const favoredSellPercentage = Math.min(
-            0.8 +
-            (mk === MK.On ? 0.05 : 0) +
-            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) +
-            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0),
-            0.95
-        );
 
-        const sellPercentage = (this.type === TowerType.Buccaneer && this.upgrades[2] >= 4) ? favoredSellPercentage :
-            0.7 +
-            (mk === MK.On ? 0.05 : 0) +
-            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) +
-            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0)
+
+        const sellPercentage = 0.7 + // default sale rate is 70%
+            (mk === MK.On ? 0.05 : 0) + // Better Sell Deals
+            (mk === MK.On && [TowerType.Farm, TowerType.Village].includes(this.type) ? 0.02 : 0) + // Flat Pack Buildings
+            (this.type === TowerType.Farm && this.upgrades[2] >= 2 ? 0.1 : 0); //Banana Salvage
+
+        const favoredSellPercentage = Math.min( sellPercentage + 0.1, 0.95);
 
         this.favoredSellValue = Math.ceil(this.cost * favoredSellPercentage);
         this.sellValue = Math.ceil(this.cost * sellPercentage);
+        if (this.type === TowerType.Buccaneer && this.upgrades[2] >= 4)
+            this.sellValue = this.favoredSellValue;
         this.sellEfficiency = (this.cost - this.sellValue) / this.income;
         this.favoredSellEfficiency = (this.cost - this.favoredSellValue) / this.income;
         this.abilitySellEfficiency = (this.cost - this.sellValue) / this.abilityIncome;


### PR DESCRIPTION
Fix for issue #5 

From my testing, BTD6 uses 32 bit floats for most of the internal calculations for the action figure. Also some inconsistent rounding is happening in the background. This code accounts for this.

This implementation is very accurate and stays precise until very high rounds. It is off by 1 occasionally at r200+ from what I have seen. I provided a comment at a possible location for this error. However do not have time to test this at the moment.

This also contains commits from @JavaTryCatchMe as I needed the roundEven function. Sorry for the quite sloppy pull request, I am new to making PR's, especially when stacking.