### PR TITLE
refactored towerinfotable cell handling, Added target totals for assistance with least tier/least cost, added enable/disable per line item!

### DIFF
--- a/src/components/TowerInfoTable/TowerInfoTable.tsx
+++ b/src/components/TowerInfoTable/TowerInfoTable.tsx
@@ -1,5 +1,5 @@
-import { Delete } from '@mui/icons-material';
-import { Card, CardContent, Container, IconButton, Typography } from '@mui/material';
+import { Delete,ExpandMore  } from '@mui/icons-material';
+import { Card, CardContent, Container, IconButton, Typography, Checkbox, Accordion, AccordionSummary, AccordionDetails, Stack, TextField } from '@mui/material';
 import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -7,45 +7,167 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import {HintTypes, Hints} from '../../models/ItemHints';
 import _ from 'lodash';
-import { FC } from 'react';
+import { FC, useState, useEffect } from 'react';
 
 import { Tower } from '../../models/Tower';
 
-const cell = (label: string, tower?: Tower, towers: Tower[] = []) => {
-  if (label === "type") {
-    return <TableCell align="left"><Typography>{tower ? tower.type : "Total"}</Typography></TableCell>;
-  } else if (label === "upgrades") {
-    return <TableCell align="left"><Typography>{tower ? tower.showUpgrades() : ""}</Typography></TableCell>;
-  } else if (label === "buffs") {
-    return <TableCell align="left"><Typography>{tower ? tower.showBuffs() : ""}</Typography></TableCell>;
-  } else if (label === "cost") {
-    return <TableCell align="right"><Typography>${tower ? tower.cost.toLocaleString() : _.sum(_.map(towers, (tower) => tower.cost)).toLocaleString()}</Typography></TableCell>;
-  } else if (label === "sellValue") {
-    return <TableCell align="right"><Typography>${tower ? tower.sellValue.toLocaleString() : _.sum(_.map(towers, (tower) => tower.sellValue)).toLocaleString()}</Typography></TableCell>;
-  } else if (label === "favoredSellValue") {
-    return <TableCell align="right"><Typography>${tower ? tower.favoredSellValue.toLocaleString() : _.sum(_.map(towers, (tower) => tower.favoredSellValue)).toLocaleString()}</Typography></TableCell>;
-  } else if (label === "income") {
-    return <TableCell align="right"><Typography>${tower ? tower.income.toLocaleString() : _.sum(_.map(towers, (tower) => tower.income)).toLocaleString()}</Typography></TableCell>;
-  } else if (label === "efficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.efficiency) ? tower.efficiency.toFixed(2) : "-") : (_.sum(_.map(towers, (tower) => tower.income)) ? (_.sum(_.map(towers, (tower) => tower.cost)) / _.sum(_.map(towers, (tower) => tower.income))).toFixed(2) : "-")}</Typography></TableCell>;
-  } else if (label === "sellEfficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.efficiency) ? tower.sellEfficiency.toFixed(2) : "-") : (_.sum(_.map(towers, (tower) => tower.income)) ? ((_.sum(_.map(towers, (tower) => tower.cost)) - _.sum(_.map(towers, (tower) => tower.sellValue))) / _.sum(_.map(towers, (tower) => tower.income))).toFixed(2) : "-")}</Typography></TableCell>;
-  } else if (label === "favoredSellEfficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.efficiency) ? tower.favoredSellEfficiency.toFixed(2) : "-") : (_.sum(_.map(towers, (tower) => tower.income)) ? ((_.sum(_.map(towers, (tower) => tower.cost)) - _.sum(_.map(towers, (tower) => tower.favoredSellValue))) / _.sum(_.map(towers, (tower) => tower.income))).toFixed(2) : "-")}</Typography></TableCell>;
-  } else if (label === "abilityIncome") {
-    return <TableCell align="right"><Typography>${tower ? tower.abilityIncome.toLocaleString() : _.sum(_.map(towers, (tower) => tower.abilityIncome)).toLocaleString()}</Typography></TableCell>;
-  } else if (label === "abilityCooldown") {
-    return <TableCell align="right"><Typography>{tower ? tower.abilityCooldown.toLocaleString() : "-"}</Typography></TableCell>;
-  } else if (label === "abilityEfficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.abilityEfficiency) ? `${tower.abilityEfficiency.toFixed(2)} uses (${(tower.abilityCooldown * tower.abilityEfficiency / 60).toFixed(2)} minutes)` : "-") : "-"}</Typography></TableCell>;
-  } else if (label === "abilitySellEfficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.abilitySellEfficiency) ? `${tower.abilitySellEfficiency.toFixed(2)} uses (${(tower.abilityCooldown * tower.abilitySellEfficiency / 60).toFixed(2)} minutes)` : "-") : "-"}</Typography></TableCell>;
-  } else if (label === "abilityFavoredSellEfficiency") {
-    return <TableCell align="right"><Typography>{tower ? (isFinite(tower.abilityFavoredSellEfficiency) ? `${tower.abilityFavoredSellEfficiency.toFixed(2)} uses (${(tower.abilityCooldown * tower.abilityFavoredSellEfficiency / 60).toFixed(2)} minutes)` : "-") : "-"}</Typography></TableCell>;
-  } else {
-    return <TableCell align="right" />
+
+const cell = (label: string, onCountedChanged: (() => void) | undefined = undefined, tower?: Tower, towers: Tower[] = [], getComparisonColumnValue: ((col: string) => number) | undefined = undefined) => {
+  function OnCountedChanged(countIt: boolean) {
+    if (tower)
+      tower.isCounted = countIt;
+    if (onCountedChanged !== undefined)
+      onCountedChanged();
   }
+  enum CellEnumFormat { Raw, String, LocaleString, Dollars, ShortDecimal }
+
+  let cellFormat = CellEnumFormat.LocaleString;
+  let cellAlign: "right" | "left" = "right";
+  let cellValue: any;
+  let cellForegroundColor: string | undefined = undefined;
+  let cellCompareToValue: any = null;//will default to cellValue unless overwritten
+  switch (label) {
+    case "type":
+      cellAlign = "left";
+      cellFormat = CellEnumFormat.String;
+      if (tower){
+        cellFormat = CellEnumFormat.Raw;
+        cellValue =  <TableCell padding='none' align={cellAlign}><Typography><Checkbox size='small' checked={tower.isCounted} onChange={(e) => OnCountedChanged(e.target.checked)} title="Enabled (consider in totals/effects on other towers)" />{tower.type}</Typography></TableCell>;
+      }
+      else if (getComparisonColumnValue !== undefined)
+        cellValue = "Target";
+      else
+        cellValue = "Total";
+      break;
+    case "upgrades":
+      cellAlign = "left";
+      cellFormat = tower ? CellEnumFormat.String : CellEnumFormat.LocaleString;
+      cellValue = tower ? tower.showUpgrades() : _.sum(_.map(towers, (tower) => tower.getTiers()));
+      break;
+    case "buffs":
+      cellAlign = "left";
+      cellFormat = CellEnumFormat.String;
+      cellValue = tower ? tower.showBuffs() : "";
+      break;
+    case "cost":
+      cellFormat = CellEnumFormat.Dollars;
+      cellValue = tower ? tower.cost : _.sum(_.map(towers, (tower) => tower.cost));
+      break;
+    case "sellValue":
+      cellFormat = CellEnumFormat.Dollars;
+      cellValue = tower ? tower.sellValue : _.sum(_.map(towers, (tower) => tower.sellValue));
+      break;
+    case "favoredSellValue":
+      cellFormat = CellEnumFormat.Dollars;
+      cellValue = tower ? tower.favoredSellValue : _.sum(_.map(towers, (tower) => tower.favoredSellValue));
+      break;
+    case "income":
+      cellFormat = CellEnumFormat.Dollars;
+      cellValue = tower ? tower.income : _.sum(_.map(towers, (tower) => tower.income));
+      break;
+    case "efficiency":
+    case "sellEfficiency":
+    case "favoredSellEfficiency":
+      let getDeductionAmount!: (tower: Tower) => number;
+      let getEfficiency!: (tower: Tower) => number;
+      if (label === "efficiency") {
+        getDeductionAmount = (tower) => 0;
+        getEfficiency = (tower) => tower.efficiency;
+  } else if (label === "sellEfficiency") {
+        getDeductionAmount = (tower) => tower.sellValue;
+        getEfficiency = (tower) => tower.sellEfficiency;
+  } else if (label === "favoredSellEfficiency") {
+        getDeductionAmount = (tower) => tower.favoredSellValue;
+        getEfficiency = (tower) => tower.favoredSellEfficiency;
+      }
+
+      cellFormat = CellEnumFormat.String;
+      cellValue = "-";
+      if (tower && isFinite(getEfficiency(tower))) {
+        cellValue = getEfficiency(tower);
+        cellFormat = CellEnumFormat.ShortDecimal;
+      }
+      else if (!tower) {
+        let totalIncome = _.sum(_.map(towers, (tower) => tower.income));
+        if (totalIncome) {
+          cellValue = (_.sum( _.map(towers, (tower) => tower.cost)) - _.sum(_.map(towers, (tower) => getDeductionAmount(tower)) ) ) / totalIncome;
+          cellFormat = CellEnumFormat.ShortDecimal;
+  }
+}
+      break;
+
+    case "abilityIncome":
+      cellFormat = CellEnumFormat.Dollars;
+      cellValue = tower ? tower.abilityIncome : _.sum(_.map(towers, (tower) => tower.abilityIncome));
+      break;
+
+    case "abilityCooldown":
+      cellValue = tower ? tower.abilityCooldown : "-";
+      if (!tower)
+        cellFormat = CellEnumFormat.String;
+      break;
+
+    case "abilityEfficiency":
+    case "abilitySellEfficiency":
+    case "abilityFavoredSellEfficiency":
+      cellFormat = CellEnumFormat.String;
+      cellValue = "-";
+      let getAbilityEfficiency!: (tower: Tower) => number;
+      if (label === "abilityEfficiency")
+        getAbilityEfficiency = (tower) => tower.abilityEfficiency;
+      else if (label === "abilitySellEfficiency")
+        getAbilityEfficiency = (tower) => tower.abilitySellEfficiency;
+      else if (label === "abilityFavoredSellEfficiency")
+        getAbilityEfficiency = (tower) => tower.abilityFavoredSellEfficiency;
+      if (tower && isFinite(getAbilityEfficiency(tower))) {
+        let cooldownMinutes = tower.abilityCooldown * getAbilityEfficiency(tower) / 60;
+        cellValue = isFinite(getAbilityEfficiency(tower)) ? `${getAbilityEfficiency(tower).toFixed(1)} (${cooldownMinutes.toFixed(1)} min)` : "-";
+        cellCompareToValue = cooldownMinutes;
+      }
+
+      break;
+    default:
+      break;
+
+  }
+  if (cellFormat === CellEnumFormat.Raw)
+    return cellValue;
+  if (getComparisonColumnValue !== undefined && label != "type") {
+    let compareVal = getComparisonColumnValue(label);
+    if (compareVal) {
+      cellValue = compareVal - (cellCompareToValue === null ? cellValue : cellCompareToValue);
+      cellForegroundColor = cellValue < 0 ? "red" : "green";
+    }
+    else {
+      cellValue = "";
+      cellFormat = CellEnumFormat.String;
+    }
+  }
+  let formattedValue = cellValue;
+  switch (cellFormat) {
+    case CellEnumFormat.Dollars:
+      let isNegative = cellValue < 0;
+      if (isNegative)
+        cellValue *= -1;
+      formattedValue = "$" + cellValue.toLocaleString();
+      if (isNegative)
+        formattedValue = `(${formattedValue})`;
+      break;
+    case CellEnumFormat.LocaleString:
+      formattedValue = cellValue.toLocaleString();
+      break;
+    case CellEnumFormat.ShortDecimal:
+      formattedValue = cellValue.toFixed(2);
+      break;
+    case CellEnumFormat.String:
+      break;
+    default:
+      throw "Format not handled";
+  }
+  return <TableCell align={cellAlign}><Typography color={cellForegroundColor} fontWeight={cellForegroundColor ? "bold" : undefined}>{formattedValue}</Typography></TableCell>;
+
 }
 
 interface TowerInfoTableProps {
@@ -58,7 +180,53 @@ const TowerInfoTable: FC<TowerInfoTableProps> = ({
   towers,
   columns = ["type", "upgrades", "buffs", "cost", "sellValue", "favoredSellValue"],
   removeTower
-}) => (
+}) =>
+{ 
+  
+  const [countedTowers, setCountedTowers] = useState(towers);
+  useEffect(() => {
+    CountedTowersChanged();
+  }, [towers]);
+  
+  function CountedTowersChanged(){
+    setCountedTowers(towers.filter( (t) => t?.isCounted === true));
+  }
+  const [columnTargets, setColumnTargets] = useState({} as { [key: string]: number });
+  function getColumnTarget(col : string) {
+      let ret = columnTargets[col];
+      return ! ret ? 0 : ret;
+  }
+  function setColumnTargetValue(col : string, val : string) {
+    let num = val ? parseInt(val) : 0;
+    let newVal = {...columnTargets};
+    newVal[col] = num;
+    setColumnTargets( newVal );
+}
+  console.log("Table called again");
+  return (
+<Stack spacing={2}>
+  <Accordion>
+  <AccordionSummary expandIcon={<ExpandMore/>} >
+          <Typography fontWeight="bold" title={Hints.getHint(HintTypes.TargetTotals)}>Target Totals</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+        <Stack direction="row" spacing={1}>
+        {columns.map(col =>
+        ["type","buffs"].includes(col) ? null :
+        <TextField
+                  label={`${_.startCase(col).replace("Ability ", "").replace("Favored Sell","Favored")}`}
+                  type="number"
+                  title={Hints.getPossibleHint(col)}
+                  defaultValue={getColumnTarget(col) == 0 ? "" : getColumnTarget(col)}
+                  onChange={(e) => setColumnTargetValue(col,e.target.value)}
+                  sx={{ width: "200px" }}
+                />
+        )
+        }
+        </Stack>
+        </AccordionDetails>
+  </Accordion>
+
   <Card>
     <CardContent>
       <Container maxWidth="xl">
@@ -66,11 +234,10 @@ const TowerInfoTable: FC<TowerInfoTableProps> = ({
           <Table sx={{ minWidth: 650 }} size="small">
             <TableHead>
               <TableRow>
-                {/* {["type", "upgrades", "buffs", "cost", "sellValue", "favoredSellValue"].map(x =>  */}
                 {columns.map(x =>  
                 <TableCell align={["type", "buffs", "upgrades"].includes(x) ? "left" : "right"}>
-                  <Typography sx={{fontWeight: 'bold'}} noWrap>
-                    {_.startCase(x).replace("Ability ", "")}
+                    <Typography sx={{ fontWeight: 'bold' }} noWrap title={Hints.getPossibleHint(x)}>
+                     {_.startCase(x).replace("Ability ", "").replace("Favored Sell","Favored")}
                   </Typography>
                 </TableCell>)}
               </TableRow>
@@ -81,7 +248,7 @@ const TowerInfoTable: FC<TowerInfoTableProps> = ({
                   sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
                 >
                   {
-                    columns.map(column => cell(column, tower))
+                    columns.map(column => cell(column, CountedTowersChanged, tower))
                   }
                   <TableCell>
                     <IconButton color="primary" aria-label="delete entry" onClick={() => {if (removeTower) removeTower(towerIndex) }}>
@@ -93,15 +260,26 @@ const TowerInfoTable: FC<TowerInfoTableProps> = ({
               <TableRow
                 sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
               >
-                {columns.map(column => cell(column, undefined, towers))}
+                {columns.map(column => cell(column, undefined, undefined, countedTowers))}
                 <TableCell />
               </TableRow>
+
+
+              { columns.some( column => getColumnTarget(column) != 0) ? 
+              <TableRow
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              > 
+                {columns.map(column => cell(column, undefined, undefined, countedTowers, getColumnTarget))}
+                <TableCell />
+              </TableRow> : <TableRow />}
+
             </TableBody>
           </Table>
         </TableContainer>
       </Container>
     </CardContent>
   </Card>
+  </Stack>
 );
-
+}
 export default TowerInfoTable;

--- a/src/models/Tower.ts
+++ b/src/models/Tower.ts
@@ -11,6 +11,7 @@ export class Tower {
     buffs!: Buff;
     cost!: number;
     income!: number;
+    isCounted!: boolean;
     efficiency!: number;
     sellValue!: number;
     favoredSellValue!: number;
@@ -29,6 +30,9 @@ export class Tower {
 
     showUpgrades() {
         return this.upgrades.join('-');
+    }
+    getTiers() : number {
+        return this.upgrades[0] + this.upgrades[1] + this.upgrades[2] + 1;
     }
 
     showBuffs() {
@@ -53,6 +57,7 @@ export class Tower {
         this.upgrades = upgrades;
         this.buffs = fixBuffs(type, buffs);
         this.type = type;
+        this.isCounted = true;
         this.sacrificeValue = sacrificeValue;
         this.farmsSacrificed = farmsSacrificed;
         this.cost = Utils.cost(this, mk, difficulty);


### PR DESCRIPTION


I refactored the cell logic in TowerInfoTable.  It has more code I think but far less hardcoded and redundant html/code.  In theory would make changes adjustments easier going forward.

This was part of three goals
1) More help on what everything is (will be in another PR but you will see references in here so it wont work without that)
2) Adding targets.   This helps save me from having 80 calculators running.  You enter a number of tiers, or total cost, etc you want in the target area and it will show you a new row (if you enter any targets if not nothing shows up) under total with the over/under to the target.  
3) Enable/Disable per line item.   Often I am trying to find the best combo but would rather not constantly add/remove towers to do so.  Now we have checkboxes, if a line isnt checked it isn't considered in the totals.

IE:
![image](https://github.com/blackeyefly/blackeyefly.github.io/assets/149419813/23b18f74-e7ba-4ba5-b80e-588418db6a60)
