### PR TITLE
utils.ts: Fix non-medium cost rounding

### DIFF
--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -231,7 +231,7 @@ export default class Utils {
         return br / Math.pow(10, roundToPlaces);
     }
     static roundEven5(n : number) {
-        return this.round5( this.roundEven(n) );
+        return this.roundEven(n / 5) * 5;
     }
 
 
@@ -293,11 +293,12 @@ export default class Utils {
 
         }
 
-        let cost: number = Utils.roundEven5(  (baseCosts[tower.type] * difficulty  + baseCostAbsoluteChange) * (1-baseDiscountPercent) );
+        let cost: number = Utils.roundEven5( (baseCosts[tower.type] * difficulty) + baseCostAbsoluteChange) * (1-baseDiscountPercent) );
         //console.log(` ${tower.type} base cost(&${baseCosts[tower.type]}) * difficulty(${difficulty}) + absoluteChange(&${baseCostAbsoluteChange}) * 1-discount(${baseDiscountPercent}) = ${cost} `);
 
         for (let i = 0; i < 3; i++) {
             for (let j = 0; j < tower.upgrades[i]; j++) {
+                let adjustedUpgradeCost = Math.floor( baseUpgradeCosts[tower.type][i][j] * difficulty );
                 let upgradeDiscountPercent = j < 3 ? villageDiscount : 0;
                 let upgradeCostAbsoluteChange: number = 0;
                 switch(tower.type) {
@@ -316,7 +317,7 @@ export default class Utils {
                     break;
                     case TowerType.Ace:
                         if (j === 4 && mkIsOn)
-                            upgradeDiscountPercent += 0.1; // Aeronautic Subsidy
+                            adjustedUpgradeCost = adjustedUpgradeCost - Math.floor(adjustedUpgradeCost * 0.1); // Aeronautic Subsidy
                     break;
                     case TowerType.Spike:
                         if (i === 0 && j === 3 && mkIsOn)
@@ -340,7 +341,7 @@ export default class Utils {
                     break;
                 }
 
-                const upgradeCost = Utils.roundEven5( (baseUpgradeCosts[tower.type][i][j] * difficulty + upgradeCostAbsoluteChange) * (1 - upgradeDiscountPercent) );
+                const upgradeCost = Utils.roundEven5( (adjustedUpgradeCost + upgradeCostAbsoluteChange) * (1 - upgradeDiscountPercent) );
                 cost += upgradeCost;
                 //console.log(`    upgrade at track ${i+1} tier: ${j+1} base ug cost(&${baseUpgradeCosts[tower.type][i][j]}) * difficulty(${difficulty}) + absoluteChange(&${upgradeCostAbsoluteChange}) * 1-discount(${upgradeDiscountPercent}) = &${upgradeCost} total cost so far: &${cost}`);
         }


### PR DESCRIPTION
Myrin told me about some inconsistency in the tower cost calculators and gave me a few examples:

Easy with MK, 1 discount:
- 010 beast: 140 -> 135
- 020 beast: 630 -> 625

I had a look into the game code and the upgrade cost calculation in `Assets.Scripts.Simulation.Towers.TowerManager$$GetTowerUpgradeCost` does not take into account the difficulty level of the current game, but it does call `Assets.Scripts.Simulation.SMath.Math$$RoundToNearestInt(float value, int nearestIntValue)` with `5` as the second argument.

Tracing from `RoundToNearestInt`, I was unable to find any XREFs that relates to the tower upgrade screen (where unmodified costs of the tower and all upgrades corresponding to the current difficulty are displayed); as far as I can tell, that screen also does not invoke `GetTowerUpgradeCost` since `GetTowerUpgradeCost` uses coordinates to compute discounts. This leads me to believe that difficulty-adjusted tower costs are pre-computed somehow, though I haven't been able to find where. I'm asking Minecool if she knows anything about this.

Anyhow splitting the calculation into a two-stop process seems to have fixed the costs.

I also changed `roundEven5` to represent what the game code actually does in `RoundToNearestInt`. I believe they are identical but I want to be safe.